### PR TITLE
発火タイミングを増やす

### DIFF
--- a/.github/workflows/add_project_board.yml
+++ b/.github/workflows/add_project_board.yml
@@ -3,9 +3,12 @@ on:
   issues:
     types:
       - opened
+      - transferred
+      - labeled
   pull_request:
     types:
       - opened
+      - labeled
 jobs:
   add-to-project:
     name: Add to Project


### PR DESCRIPTION
approve時に発火させたかったが、pull_request_reviewイベントにactionsが対応していなかったので、labeler発動⇨dependenciesラベルが貼られる⇨このactionsが発火、という依存関係を想定

Signed-off-by: RO <13445921+ROhta@users.noreply.github.com>

## 期待する挙動・状態

- skip ciの発動時もproject　boardに載るようにする

## 必要な依存関係

- labelerのactions

## 確認済み項目

- [x] syntax

## 見てほしいところ

- PR の各種設定値は適切か
  - [x] Assignee
  - [x] Projects の statusが、draft なら作業中、ready for review ならレビュー中になっているか
  - [x] 該当 Issue の項目と一致しているか
    - [x] Projects の Sprint
    - [x] Milestone
  - [x] Development で該当の Issue を設定したか