### PR TITLE
add-labelのdebug

### DIFF
--- a/.github/workflows/add_project_board.yml
+++ b/.github/workflows/add_project_board.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/add-to-project@v0.1.0
         with:
           project-url: https://github.com/users/ROhta/projects/3
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"


### PR DESCRIPTION
github-tokenのinputが無いらしい

Signed-off-by: RO <13445921+ROhta@users.noreply.github.com>

## 期待する挙動・状態

- `Input required and not supplied: github-token`のエラーが出なくなること
- add-labelのworkflowがpull request上で正常終了すること

## 必要な依存関係

- actions/add-to-project

## 確認済み項目

- [x] ドキュメントの記載通りの指定では動かないこと
- [x] このPRのadd labelが正常終了すること

## 見てほしいところ

- PR の各種設定値は適切か
  - [x] Assignee
  - [x] Projects の statusが、draft なら作業中、ready for review ならレビュー中になっているか
  - [x] 該当 Issue の項目と一致しているか
    - [x] Projects の Sprint
    - [x] Milestone
  - [x] Development で該当の Issue を設定したか
