### PR TITLE
Modify_ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     allow:
       - dependency-type: "production"
     commit-message:
-      prefix: "[skip ci]"
       include: "scope"
     labels:
       - "dependencies"
@@ -49,7 +48,6 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "[skip ci]"
       include: "scope"
     labels:
       - "dependencies"

--- a/.github/workflows/add_label.yml
+++ b/.github/workflows/add_label.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [review_requested, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 # デフォルトシェルでパイプエラーを有効化
 defaults:
@@ -12,6 +12,7 @@ defaults:
     shell: bash
 jobs:
   triage:
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,7 +2,7 @@ name: "Chromatic"
 
 on:
   pull_request:
-    types: [review_requested, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 defaults:
   run:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    types: [review_requested, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
     branches:
       - main
 
@@ -14,6 +14,7 @@ defaults:
 
 jobs:
   Dependency-Review:
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -25,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
   Build-Check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions: {}


### PR DESCRIPTION
- add_label.ymlのpull_requestトリガーイベントを`review_requested, reopened, ready_for_review`から`opened, reopened, ready_for_review`に変更
- chromatic.ymlのpull_requestトリガーイベントを`review_requested, reopened, ready_for_review`から`opened, reopened, ready_for_review`に変更
- dependency-review.ymlのpull_requestトリガーイベントを`review_requested, reopened, ready_for_review`から`opened, reopened, ready_for_review`に変更
- dependency-review.ymlのジョブに条件を追加し、ドラフトでないオープンなプルリクエストのみを対象とするように修正
- Build-Checkジョブにドラフトプルリクエストを除外する条件を追加

## 期待する挙動・状態

- dependabotのPRがCIで詰まらないこと

## 必要な依存関係

- dependabot

## 確認済み項目

- [x] syntax

## 見てほしいところ

- PR の各種設定値は適切か
  - [x] Assignee
  - [x] Projects の statusが、draft なら作業中、ready for review ならレビュー中になっているか
  - [x] 該当 Issue の項目と一致しているか
    - [x] Projects の Sprint
    - [x] Milestone
  - [x] Development で該当の Issue を設定したか
