### PR TITLE
ci: Chromatic を main push でも実行し baseline を生成

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 name: "Chromatic"
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
 
@@ -16,7 +18,9 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
-    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open' && github.actor != 'dependabot[bot]'
+    if: |
+      github.event_name == 'push' ||
+      (github.event.pull_request.draft == false && github.event.pull_request.state == 'open' && github.actor != 'dependabot[bot]')
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1.0.2-beta9
         with:
@@ -32,3 +36,4 @@ jobs:
           skip: "dependabot**"
           workingDir: "application"
           exitOnceUploaded: true
+          autoAcceptChanges: "main"


### PR DESCRIPTION
## Summary

- Chromatic workflow に `push: main` トリガを追加 → main コミットごとに baseline build が生成される
- `autoAcceptChanges: main` を設定 → main 上の build は自動承認 (PR ブランチでは自動承認されない)
- 結果: 視覚差分の無い PR は `UI Review` チェックが自動 SUCCESS に変わる

## 背景

現在 Chromatic は `pull_request` イベントのみで起動するため、main 側の baseline build が永遠に作られず、PR で常に `Patch build required for target branch` となり `UI Review` が PENDING 固定だった (#663 で実例)。

## 動作

| ケース | 動作 |
|---|---|
| main へ merge | Chromatic build → `autoAcceptChanges: main` で全 story 自動 accept → baseline 確立 |
| PR (差分なし) | baseline と比較 → 視覚差分ゼロ → `UI Review` 自動 SUCCESS |
| PR (差分あり) | baseline と比較 → 差分検出 → `UI Review` PENDING (手動 Accept/Deny) |

## 影響

- Chromatic build 数が main merge ごとに 1 件増える
- Free tier (5,000 snapshots/month) の枠内
- PR ブランチでは `autoAcceptChanges` が発動しないため安全性は維持

## Test plan

- [ ] この PR の merge 後、main の push trigger により Chromatic build が走り baseline が確立されるか確認
- [ ] 次に作る任意の小さな PR で `UI Review` が自動 SUCCESS になるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)