### PR TITLE
feat(iac): Vercel に corepack opt-in (pnpm@10 を有効化)

### DIFF
--- a/iac/hosting/env_vars.tf
+++ b/iac/hosting/env_vars.tf
@@ -1,0 +1,7 @@
+resource "vercel_project_environment_variable" "enable_corepack" {
+  project_id = vercel_project.bingo_next.id
+  team_id    = vercel_team_config.bingo_next.id
+  key        = "ENABLE_EXPERIMENTAL_COREPACK"
+  value      = "1"
+  target     = ["production", "preview", "development"]
+}


### PR DESCRIPTION
## Summary

- Vercel project に \`ENABLE_EXPERIMENTAL_COREPACK=1\` env var を Terraform で追加
- 対象環境: production, preview, development
- 以後 Vercel は \`application/package.json\` の \`"packageManager": "pnpm@10.24.0"\` を honor して corepack 経由で pnpm@10 を使う

## 背景

PR #663 で \`pnpm.patchedDependencies\` (pnpm@10 lockfile schema: \`{hash, path}\` object 形式) を追加したところ、Vercel が pnpm@9.x を使用していたため \`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\` でデプロイ失敗。プロジェクト作成日ベースの fallback で pnpm@9 を選んでいたのが原因 (commit \`9df2618\` で確認 / \`db75e54\` で revert)。

corepack opt-in により Vercel が \`packageManager\` を honor → 開発環境 (Volta@pnpm@10.24.0) と Vercel の pnpm バージョンが揃う。

## Apply 手順

1. この PR で Terraform Cloud の plan を確認 (\`Terraform Cloud/bingo_next/repo-id-...\` check)
2. merge
3. メンテナが \`terraform apply\` を実行 (env var を Vercel project に反映)
4. 以後の Vercel デプロイは pnpm@10.24.0 で動作

## 副次効果

apply 後は pnpm@10 専用機能 (新 \`overrides\` syntax、\`patchedDependencies\` の \`{hash, path}\` 形式 等) を application/ で安全に使えるようになる。具体的には、PR #663 で revert した \`@storybook/builder-webpack5\` の \`dist/preset.js\` stub patch を別 PR で復帰させることができ、Storybook の preset lookup warning を消せる。

## Test plan

- [ ] Terraform Cloud の plan output で env var 追加が想定通りか確認
- [ ] merge → \`terraform apply\` 実行
- [ ] 次の任意の PR で Vercel build ログに \`Using pnpm@10.24.0\` 相当の表示があるか確認 (現状は \`Using pnpm@9.x based on project creation date\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)