### PR TITLE
fix(iac): corepack env var の development target を削除 (apply 失敗修正)

### DIFF
--- a/iac/hosting/env_vars.tf
+++ b/iac/hosting/env_vars.tf
@@ -3,5 +3,5 @@ resource "vercel_project_environment_variable" "enable_corepack" {
   team_id    = vercel_team_config.bingo_next.id
   key        = "ENABLE_EXPERIMENTAL_COREPACK"
   value      = "1"
-  target     = ["production", "preview", "development"]
+  target     = ["production", "preview"]
 }


### PR DESCRIPTION
## Summary

PR #665 のマージ後 Terraform Cloud auto-apply が下記エラーで失敗:

\`\`\`
Error creating project environment variable
Cannot create a Sensitive Environment Variable with \`target=development\`.
Sensitive Environment Variables are enforced for the entire team.
\`\`\`

\`team.tf\` の \`sensitive_environment_variable_policy = "on"\` により env var が強制 sensitive 化され、Vercel の制約 (sensitive env var は development target 不可) に抵触したため。

## 修正

\`target = ["production", "preview", "development"]\` → \`target = ["production", "preview"]\`

## なぜ development を落として OK か

- \`ENABLE_EXPERIMENTAL_COREPACK\` は **Vercel 側 build 環境** で意味を持つ env var (preview/production build)
- Vercel の \`development\` target は \`vercel dev\` CLI 用。本プロジェクトはローカル dev を Volta + pnpm@10 直接で回しており \`vercel dev\` を使っていない
- 機能的損失なし

## 別案を採用しなかった理由

- team の sensitive enforcement を外す: 他の secret (Vercel API token 等) も非 sensitive 化され影響範囲が広い
- resource 側で \`sensitive = false\` 明示: team policy に上書きされて効かない

## Apply

merge 後、Terraform Cloud auto-apply が再走して env var を作成 → 以後 Vercel が \`packageManager: pnpm@10.24.0\` を honor。

## Test plan

- [ ] Terraform Cloud plan で env var 1 件 add (production, preview のみ) を確認
- [ ] merge 後 auto-apply が success
- [ ] 次の任意の PR で Vercel build ログに \`Using pnpm@10\` 表示があるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)