### PR TITLE
docs: SECURITY.md の構成を整理し dependabot version updates を主たる対応方針として明記

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,5 +15,5 @@
 ### 対応方針
 
 - 依存関係は基本的に [dependabot version updates](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) に基づいて対応します
-  - [`versioning-strategy: increase-if-necessary`](https://github.com/ROhta/bingo_next/blob/main/.github/dependabot.yml#L25) を設定し、必要なアップデートにのみ追従します
+  - [`versioning-strategy: increase-if-necessary`](https://github.com/ROhta/bingo_next/blob/main/.github/dependabot.yml) を設定し、必要なアップデートにのみ追従します
 - [dependabot security updates](https://docs.github.com/ja/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) で検知された脆弱性にも対応します

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,12 +1,19 @@
 # セキュリティーポリシー
 
-## サポートヴァージョン
+## サポートバージョン
 
 - 最新版のみサポート
 - 最新のリリースバージョンのソースコードを使用してください
 
-## 脆弱性の対応方針
+## 脆弱性の報告
 
-- 基本的に[dependabot security updates](https://help.github.com/ja/github/managing-security-vulnerabilities/configuring-automated-security-updates)に基づいて対応します
-  - [`versioning-strategy: increase-if-necessary`](https://github.com/ROhta/bingo_next/blob/faa8095bd4311da67c26084cb512584387bfd695/.github/dependabot.yml#L25)と設定し、必要なアップデートにのみ追従します
-- 未対応の脆弱性で対応すべきものがあったら、[Discussions](https://github.com/ROhta/bingo_next/discussions/new?category=maybe-bug)に書き込んでくださると助かります
+### 報告先
+
+- 機微な脆弱性は [GitHub Security Advisories](https://github.com/ROhta/bingo_next/security/advisories/new) から非公開で報告してください
+- 公開で議論できる気付き・相談は [Discussions](https://github.com/ROhta/bingo_next/discussions/new?category=maybe-bug) に書き込んでください
+
+### 対応方針
+
+- 依存関係は基本的に [dependabot version updates](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) に基づいて対応します
+  - [`versioning-strategy: increase-if-necessary`](https://github.com/ROhta/bingo_next/blob/main/.github/dependabot.yml#L25) を設定し、必要なアップデートにのみ追従します
+- [dependabot security updates](https://docs.github.com/ja/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) で検知された脆弱性にも対応します


### PR DESCRIPTION
## Summary

- `.github/SECURITY.md` を GitHub 標準のセクション構成（Supported Versions / Reporting a Vulnerability）に再編
- 主たる対応方針として `dependabot version updates` を明記し、`dependabot security updates` で検知された脆弱性にも対応する旨を補記
- Private Vulnerability Reporting (GitHub Security Advisories) を報告先に追加し、表記揺れ・固定 SHA リンク・旧ドメインリンクを是正

## 変更詳細

- セクション再編: `脆弱性の対応方針` → `脆弱性の報告`（`### 報告先` / `### 対応方針` の2サブセクション）
- `サポートヴァージョン` → `サポートバージョン`
- 報告先に `GitHub Security Advisories` (`security/advisories/new`) を追加し、`Discussions` を併記
- 対応方針の主軸を `dependabot version updates` に切り替え、`dependabot security updates` 検知分も対応する旨を追記
- `dependabot.yml` への固定 SHA リンク (`faa8095...`) を `blob/main/...` に変更
- 旧 `help.github.com` リンクを現行の `docs.github.com` ドメインに更新

## Test plan

- [ ] GitHub 上で SECURITY.md がレンダリングされ、見出し階層が崩れていないこと
- [ ] `Security Advisories` リンクが Security タブの新規アドバイザリ作成画面に遷移すること
- [ ] `Discussions` リンクが `maybe-bug` カテゴリで起動すること
- [ ] `dependabot.yml` リンクが `versioning-strategy` 行に着地すること（`#L25`）
- [ ] dependabot 関連の docs.github.com リンクが現行ドキュメントを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)