### PR TITLE
fix(deps): Dependabot directory を実構造に追従

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,10 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 10
-    directory: "/"
-    allow:
-      - dependency-type: "all"
+    directories:
+      - "/iac/**"
+    labels:
+      - "dependencies"
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "_"
@@ -51,9 +52,9 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 10
-    directory: "/"
-    allow:
-      - dependency-type: "all"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels:
       - "dependencies"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- `package-ecosystem: terraform` の `directory: \"/\"` を `directories: [\"/iac/**\"]` に修正。`.tf` ファイルは `iac/hosting/` 配下にあり、ルートには存在しないため Dependabot が長期間 Terraform / Vercel provider を一切検知できていなかった
- `package-ecosystem: github-actions` で `directories: [\"/\", \"/.github/actions/*\"]` を指定し、`.github/actions/setup-node-pnpm/action.yml` 内の `uses:` (pnpm/action-setup, actions/setup-node など) もカバー
- 冗長だった `allow: dependency-type: \"all\"` を terraform / github-actions の両方から削除 (Dependabot のデフォルト動作)
- terraform セクションに `labels: [\"dependencies\"]` を追加し npm / github-actions と一貫性を確保

## 問題の根拠

### Terraform 検出停止
- PR #596 (2025-11-17) の diff で `directory: \"/iac\"` → `directory: \"/\"` に誤変更されている
- Terraform 関連 Dependabot PR は **PR #526 (2025-02-28) を最後に 0 件**
- `iac/hosting/main.tf` には `vercel/vercel ~> 3.17`, `required_version ~> 1.13` の制約があり、本来更新 PR が出るはず

### Composite action 未カバー
- `pnpm/action-setup` は v5.0.0 (2026-03-17), v6.0.x (2026-04-30〜) をリリース済み
- 該当の Dependabot PR は履歴上 0 件 — `directory: \"/\"` だけでは composite action 内が検出されていない

## 注意

- マージ後の次回 Dependabot スケジュール (terraform: 金, github-actions: 木) で **滞留していた更新 PR が一気に流れ込む可能性** あり

## Test plan

- [ ] YAML パース確認済 (`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"`)
- [ ] マージ後、初回スケジュールで terraform / composite action 関連の PR が発火することを Actions タブから確認
- [ ] Dependabot の Insights ページで該当エコシステムが有効化されていることを確認