### PR TITLE
chore(ci): labeler に "enhance-3 ドキュメント" ラベルを追加

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
 dependencies:
   - changed-files:
     - any-glob-to-any-file: ['package.json', 'pnpm-lock.yaml']
+
+"enhance-3 ドキュメント":
+  - changed-files:
+    - any-glob-to-any-file: ['**/*.md', '.apm/**']


### PR DESCRIPTION
## Summary
- `.github/labeler.yml` に `enhance-3 ドキュメント` ラベルのルールを追加
- glob: `**/*.md` および `.apm/**` を含む PR に自動付与
- 既存 `dependencies` ラベル（package.json / pnpm-lock.yaml）はそのまま

## Why
- ドキュメント更新（README・SECURITY・PULL_REQUEST_TEMPLATE 等）と APM SoT（#667 で導入）配下の instructions 更新を、レビュアーが一目で識別できるようにするため
- 既存ラベル `enhance-3 ドキュメント` は手動付与だったが、`actions/labeler@v6.1.0` で自動化

## Test plan
- [ ] この PR 自体には `**/*.md` 変更が無いため `enhance-3 ドキュメント` は付かないこと（labeler.yml のみ → `dependencies` も付かない）
- [ ] 試しに README.md などを更新した PR でラベルが自動付与されることを後続 PR で確認
- [ ] 既存 `dependencies` ラベル動作にリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)