### PR TITLE
fix(infra): リポジトリルートに stub package.json を追加し Vercel corepack opt-in を実効化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "bingo-next-workspace",
+	"private": true,
+	"packageManager": "pnpm@10.24.0"
+}


### PR DESCRIPTION
## Summary

- リポジトリルートに `packageManager` のみ持つ stub `package.json` を追加
- これにより Vercel の corepack-enable が成立し、`ENABLE_EXPERIMENTAL_COREPACK=1` が初めて実効化される
- pnpm@9.x fallback から pnpm@10.24.0 に切り替わり、`ERR_INVALID_THIS` (pnpm@9 + 現行 Node の既知バグ) による preview deploy 失敗が解消される見込み

## 背景

PR #665 (`feat(iac): Vercel に corepack opt-in (pnpm@10 を有効化)`) で IaC に `ENABLE_EXPERIMENTAL_COREPACK=1` を追加したが、Vercel の corepack-enable ロジックは **Root Directory (`application/`) ではなくリポジトリルートの `package.json`** で `packageManager` を探す挙動になっており、

```
WARNING! Could not enable corepack because package.json is missing "packageManager" property
```

が出て有効化されないままになっていた。その結果 Vercel 同梱の pnpm@9.x が使われ、pnpm@10 形式の lockfile に対して registry fetch 段階で `ERR_PNPM_META_FETCH_FAIL: Value of "this" must be of type URLSearchParams` を再現性 100% で起こしていた（直近の PR #668 で顕在化）。

## 変更内容

新規ファイル: `/package.json`

```json
{
	"name": "bingo-next-workspace",
	"private": true,
	"packageManager": "pnpm@10.24.0"
}
```

- `private: true` で npm publish 対象外を明示
- `packageManager` のみで他フィールドは持たない（依存も script も追加しない）
- 既存 `application/package.json` の `packageManager` と同期させる必要があるため、将来 pnpm を更新するときは 2 箇所更新が必要（pnpm-workspace.yaml 化はフォローアップで検討）

## Test plan

- [ ] 本 PR の Vercel preview deploy が成功すること
- [ ] ビルドログ冒頭の `Could not enable corepack because package.json is missing "packageManager" property` が消えること
- [ ] `pnpm install` の registry fetch が `ERR_INVALID_THIS` でこけないこと
- [ ] preview URL でアプリが表示されること
- [ ] ローカル開発 (`cd application && pnpm i --frozen-lockfile && pnpm run dev`) に影響しないこと

## 参考

- 関連 PR: #665 (corepack opt-in IaC)、#668 (docs PR、本問題で Vercel CI が落ちて admin override merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)