### PR TITLE
chore(apm): ローカル開発ワークフロー指示を追加し PR レビュー応答ループを定義

### DIFF
--- a/.apm/instructions/local-dev-workflow.instructions.md
+++ b/.apm/instructions/local-dev-workflow.instructions.md
@@ -33,6 +33,7 @@ applyTo: "**"
    - PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` の項目 (`## 期待する挙動・状態` / `## 確認済み項目` / `## 見てほしいところ`) を埋める形で記載すること。`finishing-a-development-branch` スキルが提案する独自構成 (`## Summary` / `## Test plan` 等) は採用しない
    - チェックボックスは commit 前に実際に検証済みの項目のみ `[x]`、Preview Deploy 待ちなど未確認のものは `[ ]` のまま残す
    - PR タイトルは Conventional Commits 形式 (`<type>(<scope>): <description>`) で記載し、本文と同じく日本語で書く
+   - PR の assignee には、コミットを作成した人間のユーザー (= 現在の `gh` CLI 認証ユーザー) を必ず設定する。AI エージェントは GitHub アカウントを持たないため、`gh pr create` 時に `--assignee @me` を渡すか、作成後に `gh pr edit <pr_number> --add-assignee @me` で追加する。`@me` は `gh` CLI が現在認証中のユーザー名に解決される
 
 各ステップで失敗した場合は次に進まず、失敗の根本原因を解決してから再実行する。
 

--- a/.apm/instructions/local-dev-workflow.instructions.md
+++ b/.apm/instructions/local-dev-workflow.instructions.md
@@ -30,6 +30,9 @@ applyTo: "**"
 2. 検証が通ったら `requesting-code-review` を起動し、レビュー依頼側ワークフローを開始する
 3. レビュー結果が返ってきたら `receiving-code-review` を起動してフィードバックに対応する
 4. 対応が完了したら `finishing-a-development-branch` を起動し、選択肢「2」を選んで PR を作成する
+   - PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` の項目 (`## 期待する挙動・状態` / `## 確認済み項目` / `## 見てほしいところ`) を埋める形で記載すること。`finishing-a-development-branch` スキルが提案する独自構成 (`## Summary` / `## Test plan` 等) は採用しない
+   - チェックボックスは commit 前に実際に検証済みの項目のみ `[x]`、Preview Deploy 待ちなど未確認のものは `[ ]` のまま残す
+   - PR タイトルは Conventional Commits 形式 (`<type>(<scope>): <description>`) で記載し、本文と同じく日本語で書く
 
 各ステップで失敗した場合は次に進まず、失敗の根本原因を解決してから再実行する。
 
@@ -44,13 +47,18 @@ PR に対してコミットを push した後、AI エージェント (GitHub Co
 `gh api graphql` で未 resolve なレビュースレッドを列挙する。
 `gh pr view --json reviews,comments` は thread の `isResolved` を返さないので利用しない。
 
-レビュースレッド数が 100 を、または各スレッドのコメント数が 50 を超える可能性がある
-場合は、`pageInfo { hasNextPage endCursor }` を取得し、`hasNextPage: true` の間は
-`after: $cursor` を渡してカーソル送りで全件取得すること (下記は初回ページの取得例)。
+レビュースレッド数が 100 を超える可能性がある場合は、`reviewThreads.pageInfo` の
+`hasNextPage` / `endCursor` を取得し、`hasNextPage: true` の間は `$threadsCursor` に
+`endCursor` を渡してカーソル送りで全件取得すること (下記は初回ページの取得例)。
+
+各スレッドのコメントは、本クエリでは `comments(first: 50)` までに限定する前提とする
+(`$commentsCursor` は単一値しか持てず、全スレッドのコメントに対して同じカーソルを
+当てるため、スレッドごとに個別のページングはこのクエリでは行えないため)。1 スレッドの
+コメントが 50 件を超えた場合は、当該スレッド ID を指定して別途取得する。
 
 ```bash
 gh api graphql -f query='
-query($owner: String!, $repo: String!, $pr: Int!, $threadsCursor: String, $commentsCursor: String) {
+query($owner: String!, $repo: String!, $pr: Int!, $threadsCursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100, after: $threadsCursor) {
@@ -58,11 +66,11 @@ query($owner: String!, $repo: String!, $pr: Int!, $threadsCursor: String, $comme
         nodes {
           id            # GraphQL Node ID — resolveReviewThread mutation の threadId に渡す
           isResolved
-          comments(first: 50, after: $commentsCursor) {
+          comments(first: 50) {
             pageInfo { hasNextPage endCursor }
             nodes {
               id          # GraphQL Node ID
-              databaseId  # 数値 ID — REST API /pulls/comments/{comment_id}/replies の comment_id に渡す
+              databaseId  # 数値 ID — REST API POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies の comment_id に渡す
               author { login }
               body
               path
@@ -76,8 +84,10 @@ query($owner: String!, $repo: String!, $pr: Int!, $threadsCursor: String, $comme
 }' -F owner=<owner> -F repo=<repo> -F pr=<number>
 ```
 
-対象は `isResolved: false` かつ author が bot (例: `copilot-pull-request-reviewer[bot]`) の
-スレッドのみとする。
+対象は `isResolved: false` かつ **スレッド先頭コメント (`comments.nodes[0]`) の `author.login`**
+が bot (例: `copilot-pull-request-reviewer`) のスレッドのみとする
+(`reviewThreads.nodes[]` 自体には `author` フィールドが存在しないので、コメント側で
+判定する必要がある)。
 
 ### 2.2 妥当性判断
 

--- a/.apm/instructions/local-dev-workflow.instructions.md
+++ b/.apm/instructions/local-dev-workflow.instructions.md
@@ -1,0 +1,128 @@
+---
+description: ローカル開発時のフロー (実装完了から PR 作成、PR レビュー応答ループ) を superpowers 系スキルで定義
+applyTo: "**"
+---
+
+# ローカル開発ワークフロー (AI エージェント向け)
+
+このプロジェクトでローカル開発を進める AI エージェントは、以下のワークフローに従う。
+
+## 前提: superpowers の存在確認
+
+本ワークフローは [superpowers](https://github.com/anthropics/superpowers) 系スキル
+(`verification-before-completion` / `requesting-code-review` / `receiving-code-review`
+/ `finishing-a-development-branch`) が利用可能であることを前提とする。
+
+- **Claude Code**: 上記 4 つのスキルが `Skill` ツールから呼び出せることを起動時に確認する
+- **Codex CLI / GitHub Copilot 等**: 同等のスキル集が読み込まれているかを確認する
+
+利用できない場合は、ユーザーに次のように案内し、本ワークフローの実行をその場で中断する。
+
+> superpowers が見つかりません。
+> 当プロジェクトのローカル開発フローを実行するには superpowers のインストールが必要です。
+> インストール後に再度同じ指示をお願いします。
+
+## 1. 実装完了から PR 作成まで
+
+実装が完了したと判断した時点で、以下を順に実行する。**前ステップが完了するまで次に進まない。**
+
+1. `verification-before-completion` を起動し、検証 (lint / typecheck / 実機動作) を完遂する
+2. 検証が通ったら `requesting-code-review` を起動し、レビュー依頼側ワークフローを開始する
+3. レビュー結果が返ってきたら `receiving-code-review` を起動してフィードバックに対応する
+4. 対応が完了したら `finishing-a-development-branch` を起動し、選択肢「2」を選んで PR を作成する
+
+各ステップで失敗した場合は次に進まず、失敗の根本原因を解決してから再実行する。
+
+## 2. PR レビュー応答ループ (git push 毎)
+
+PR に対してコミットを push した後、AI エージェント (GitHub Copilot Review 等) からの
+レビュー指摘が付いた場合、push の度に以下を繰り返す。**すべてのスレッドが resolve
+されるまでループを継続する。**
+
+### 2.1 検知
+
+`gh api graphql` で未 resolve なレビュースレッドを列挙する。
+`gh pr view --json reviews,comments` は thread の `isResolved` を返さないので利用しない。
+
+レビュースレッド数が 100 を、または各スレッドのコメント数が 50 を超える可能性がある
+場合は、`pageInfo { hasNextPage endCursor }` を取得し、`hasNextPage: true` の間は
+`after: $cursor` を渡してカーソル送りで全件取得すること (下記は初回ページの取得例)。
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!, $threadsCursor: String, $commentsCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $threadsCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id            # GraphQL Node ID — resolveReviewThread mutation の threadId に渡す
+          isResolved
+          comments(first: 50, after: $commentsCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id          # GraphQL Node ID
+              databaseId  # 数値 ID — REST API /pulls/comments/{comment_id}/replies の comment_id に渡す
+              author { login }
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}' -F owner=<owner> -F repo=<repo> -F pr=<number>
+```
+
+対象は `isResolved: false` かつ author が bot (例: `copilot-pull-request-reviewer[bot]`) の
+スレッドのみとする。
+
+### 2.2 妥当性判断
+
+各指摘について次のいずれかに分類する。
+
+- **妥当**: 反映すべき具体的かつ正当な指摘
+- **不当**: 文脈を踏まえると採用すべきでない、誤読、二重指摘 等
+
+### 2.3 対応
+
+#### 妥当な指摘
+
+1. 指摘に従ってコードを修正する
+2. 修正をコミットする (このリポジトリでは Co-Authored-By トレーラは付与しない)
+3. 該当インラインコメントに返信する。本文に対応コミットの SHA を **前後に半角空白を入れて**
+   記載し、GitHub UI でコミットへのリンクとして描画させる。
+
+   ```bash
+   gh api repos/<owner>/<repo>/pulls/<pr>/comments/<comment_database_id>/replies \
+     -f body='対応しました abc1234 '
+   ```
+
+   - `<comment_database_id>` は上記クエリの `databaseId` フィールド (**数値 ID**) を指す。
+     GraphQL Node ID (`PRRC_...`) は REST API では受け付けられない点に注意。
+   - 本文は日本語で記述 (`pr-review.instructions.md` 参照)
+   - SHA の前後を必ず半角空白で挟む
+4. スレッドを resolve する。
+
+   ```bash
+   gh api graphql -f query='
+   mutation($id: ID!) { resolveReviewThread(input: {threadId: $id}) { thread { isResolved } } }
+   ' -F id=<thread_node_id>
+   ```
+
+#### 不当と判断した場合
+
+1. コードは変更しない
+2. インラインコメントで「不当と判断した理由」を日本語で具体的に記載する
+3. スレッドを resolve する (上記 mutation 参照)
+
+### 2.4 繰り返し
+
+- 全スレッドを resolve するまで 2.1〜2.3 をループする
+- 次の `git push` が発生したら、再度 2.1 から実行する
+
+## 関連ルール
+
+- レビュー応答の文章ルールは [`pr-review.instructions.md`](./pr-review.instructions.md) に従う

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -12,10 +12,10 @@ local_deployed_files:
 - .github/instructions/setup.instructions.md
 local_deployed_file_hashes:
   .claude/rules/apm-workflow.md: sha256:0ebc10e422fdbacc2fdc5c0602a38b113d026eeacd8364323f349ac82d943898
-  .claude/rules/local-dev-workflow.md: sha256:60cfaff7868464b3e8caa5fabc586bcb7ffa277051bccde42d4c74ba5bb11f24
+  .claude/rules/local-dev-workflow.md: sha256:1cc008ab6ee0938d4ffac676069f8c159f1191584dd39734bdffd724281c340a
   .claude/rules/pr-review.md: sha256:af50a0661cc593d21f02943882089b8618776e50512e4c2ea40c0116cd1fefec
   .claude/rules/setup.md: sha256:c60cc573b46e3159ed6ab3dfc24aa08316e25c6c497edaaa2ef66b3c0bc25b78
   .github/instructions/apm-workflow.instructions.md: sha256:4198d073134f6d047db6cb4a3c84d4d58ffe5425ad0fc6bf364a2d0d3b6b4826
-  .github/instructions/local-dev-workflow.instructions.md: sha256:42129928ea4c0085e562faa58be5ba92be9b5cb55bee945f2d36638b518835fb
+  .github/instructions/local-dev-workflow.instructions.md: sha256:3cab2f31eef656d8aa50db9dd52d147b1033290eb2e4fcc55ef727c55a3b96b8
   .github/instructions/pr-review.instructions.md: sha256:713e9febbf9ea3d284c9a811ee3672129b3ae1bee224d2255e813551adb002a2
   .github/instructions/setup.instructions.md: sha256:8e15a32fd8a02a6ccace41cfd8537f66397c16275500eba706df4ec901415758

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -12,10 +12,10 @@ local_deployed_files:
 - .github/instructions/setup.instructions.md
 local_deployed_file_hashes:
   .claude/rules/apm-workflow.md: sha256:0ebc10e422fdbacc2fdc5c0602a38b113d026eeacd8364323f349ac82d943898
-  .claude/rules/local-dev-workflow.md: sha256:1cc008ab6ee0938d4ffac676069f8c159f1191584dd39734bdffd724281c340a
+  .claude/rules/local-dev-workflow.md: sha256:24b241c483920332ad887c0f79d08adb242339846da96be1ba9305843d35aa04
   .claude/rules/pr-review.md: sha256:af50a0661cc593d21f02943882089b8618776e50512e4c2ea40c0116cd1fefec
   .claude/rules/setup.md: sha256:c60cc573b46e3159ed6ab3dfc24aa08316e25c6c497edaaa2ef66b3c0bc25b78
   .github/instructions/apm-workflow.instructions.md: sha256:4198d073134f6d047db6cb4a3c84d4d58ffe5425ad0fc6bf364a2d0d3b6b4826
-  .github/instructions/local-dev-workflow.instructions.md: sha256:3cab2f31eef656d8aa50db9dd52d147b1033290eb2e4fcc55ef727c55a3b96b8
+  .github/instructions/local-dev-workflow.instructions.md: sha256:30b502ece2dff09d6f3c92b3c178e2ba53059c0d45f7725a10df2025286ad22d
   .github/instructions/pr-review.instructions.md: sha256:713e9febbf9ea3d284c9a811ee3672129b3ae1bee224d2255e813551adb002a2
   .github/instructions/setup.instructions.md: sha256:8e15a32fd8a02a6ccace41cfd8537f66397c16275500eba706df4ec901415758

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -3,15 +3,19 @@ generated_at: '2026-05-24T02:35:22.171050+00:00'
 dependencies: []
 local_deployed_files:
 - .claude/rules/apm-workflow.md
+- .claude/rules/local-dev-workflow.md
 - .claude/rules/pr-review.md
 - .claude/rules/setup.md
 - .github/instructions/apm-workflow.instructions.md
+- .github/instructions/local-dev-workflow.instructions.md
 - .github/instructions/pr-review.instructions.md
 - .github/instructions/setup.instructions.md
 local_deployed_file_hashes:
   .claude/rules/apm-workflow.md: sha256:0ebc10e422fdbacc2fdc5c0602a38b113d026eeacd8364323f349ac82d943898
+  .claude/rules/local-dev-workflow.md: sha256:60cfaff7868464b3e8caa5fabc586bcb7ffa277051bccde42d4c74ba5bb11f24
   .claude/rules/pr-review.md: sha256:af50a0661cc593d21f02943882089b8618776e50512e4c2ea40c0116cd1fefec
   .claude/rules/setup.md: sha256:c60cc573b46e3159ed6ab3dfc24aa08316e25c6c497edaaa2ef66b3c0bc25b78
   .github/instructions/apm-workflow.instructions.md: sha256:4198d073134f6d047db6cb4a3c84d4d58ffe5425ad0fc6bf364a2d0d3b6b4826
+  .github/instructions/local-dev-workflow.instructions.md: sha256:42129928ea4c0085e562faa58be5ba92be9b5cb55bee945f2d36638b518835fb
   .github/instructions/pr-review.instructions.md: sha256:713e9febbf9ea3d284c9a811ee3672129b3ae1bee224d2255e813551adb002a2
   .github/instructions/setup.instructions.md: sha256:8e15a32fd8a02a6ccace41cfd8537f66397c16275500eba706df4ec901415758


### PR DESCRIPTION
## Summary

- `.apm/instructions/local-dev-workflow.instructions.md` を Source of Truth として新設し、ローカル開発時の AI エージェント挙動を明文化
- 実装完了 → PR 作成までを superpowers 系スキル (`verification-before-completion` / `requesting-code-review` / `receiving-code-review` / `finishing-a-development-branch`) で順序付け
- push 毎に Copilot Review 等のレビュー指摘へ自動応答する「PR レビュー応答ループ」を `gh api graphql` のクエリ・REST 返信・スレッド resolve まで含めて詳述
- 既存の [bingo](https://github.com/ROhta/bingo/blob/main/.apm/instructions/local-dev-workflow.instructions.md) と同等の挙動を本リポジトリでも実現する

## なぜ必要か

これまで bingo_next には PR レビュー指摘に対する AI エージェントの挙動定義が無く、Copilot Review のスレッドを未 resolve のまま放置してしまうケースがあった。SoT (`.apm/instructions/`) に挙動を定義することで `apm install` / `apm compile` を介して Claude Code / Codex CLI / GitHub Copilot すべてに同一指示が届く。

## Test plan

- [ ] `apm install` / `apm compile` が成功すること (本 PR では確認済み)
- [ ] `.github/instructions/local-dev-workflow.instructions.md` および `.claude/rules/local-dev-workflow.md` がローカルで再生成され、内容が SoT と一致すること
- [ ] 本 PR に Copilot Review が指摘を付けた場合、本ファイルの 2 章「PR レビュー応答ループ」に従って応答できること