### PR TITLE
docs(llms): llms.txt を公式仕様準拠に整理しリンクを拡充

### DIFF
--- a/application/public/llms.txt
+++ b/application/public/llms.txt
@@ -1,30 +1,46 @@
 # Bingo Next
 
-> パーティーやイベントで使える、シンプルで使いやすいWebビンゴマシンアプリケーションです。
+> Web ブラウザだけで動作する、パーティーやイベント向けのオープンソースビンゴ抽選アプリ。
 
-Bingo Nextは、Next.jsで構築されたオープンソースのビンゴ抽選アプリです。ブラウザ上で動作し、インストール不要で誰でもすぐに利用できます。
+Next.js (React 19) で構築され、Vercel 上でホスティングされています。インストール不要で、本番 URL を開くだけでビンゴ抽選を開始できます。
 
-## 主な機能
+**主な機能**
 
-- 1〜75の番号をランダムに抽選
+- 1〜75 の番号からランダムに抽選
 - ドラムロール効果音付きの演出
 - 抽選済み番号の履歴表示
 - リセット機能で何度でも再利用可能
 - レスポンシブデザインで様々なデバイスに対応
 
-## 技術スタック
+**技術スタック**
 
-- フレームワーク: Next.js 16 (React 19)
-- 言語: TypeScript
-- スタイリング: Tailwind CSS
-- ホスティング: Vercel
-- IaC: Terraform
+- Next.js 16 / React 19 / TypeScript
+- Tailwind CSS
+- Vercel (ホスティング・監視)
+- Terraform (IaC, HashiCorp Cloud バックエンド)
 
 ## リンク
 
-- [ソースコード](https://github.com/ROhta/bingo_next): GitHubリポジトリ
-- [プロダクト](https://rohta-bingo-next.vercel.app/): 本番環境
+- [本番環境](https://rohta-bingo-next.vercel.app/): 公開デプロイ。ブラウザで開くとそのまま利用可能
+- [GitHub リポジトリ](https://github.com/ROhta/bingo_next): ソースコード一式
+- [README](https://github.com/ROhta/bingo_next/blob/main/README.md): プロジェクト概要とドキュメント索引
+- [LICENSE](https://github.com/ROhta/bingo_next/blob/main/LICENSE): GPL-3.0-or-later
 
-## ライセンス
+## ドキュメント
 
-GPL-3.0-or-later
+- [セットアップ手順](https://github.com/ROhta/bingo_next/blob/main/.apm/instructions/setup.instructions.md): ローカル開発環境構築 (application / iac)
+- [PR レビュー方針](https://github.com/ROhta/bingo_next/blob/main/.apm/instructions/pr-review.instructions.md): レビュー時のコミュニケーションルール
+- [APM 運用ルール](https://github.com/ROhta/bingo_next/blob/main/.apm/instructions/apm-workflow.instructions.md): AI エージェント向け指示の管理方法
+
+## ソースコード
+
+- [app/page.tsx](https://github.com/ROhta/bingo_next/blob/main/application/src/app/page.tsx): ビンゴ画面のエントリポイント
+- [hooks/use-bingo.ts](https://github.com/ROhta/bingo_next/blob/main/application/src/hooks/use-bingo.ts): 抽選ロジック
+- [hooks/use-audio.ts](https://github.com/ROhta/bingo_next/blob/main/application/src/hooks/use-audio.ts): 効果音再生
+- [components/](https://github.com/ROhta/bingo_next/tree/main/application/src/components): UI コンポーネント
+- [iac/hosting/](https://github.com/ROhta/bingo_next/tree/main/iac/hosting): Vercel ホスティングの Terraform 定義
+
+## Optional
+
+- [Security Policy](https://github.com/ROhta/bingo_next/blob/main/.github/SECURITY.md): 脆弱性報告の手順
+- [GitHub Actions workflows](https://github.com/ROhta/bingo_next/tree/main/.github/workflows): CI/CD 定義 (build-check, chromatic 等)


### PR DESCRIPTION
## 期待する挙動・状態

- `/llms.txt` パスで [llmstxt.org 公式仕様](https://llmstxt.org/) 準拠の Markdown が配信される
- AI エージェント/LLM が、本番環境・ソースコード・README・LICENSE・`.apm/instructions/*`・SECURITY・CI workflows へ絶対 URL で辿れる
- H2 はファイルリスト専用という仕様規約に違反した「## 主な機能」「## 技術スタック」「## ライセンス」が解消され、details セクション (bold ラベル + リスト) に整理される

## 確認済み項目

- [x] llmstxt.org 公式仕様 (`# H1` + `> blockquote` + 詳細セクション + リンク集 H2 + `## Optional`) に沿った構造に再編
- [x] llms.txt 内のすべての GitHub 絶対 URL がリポジトリの実在ファイル/ディレクトリを指す (commit 前に `for f in ...; do [ -e "$f" ]; done` で全件検証)
- [x] `lint-staged` 対象 (`*.{mjs,ts,tsx}`) の対象外であり、husky pre-commit による干渉がないことを `application/package.json` で確認
- [x] blockquote と詳細段落の重複を排除
- [ ] Preview Deploy で `https://.../llms.txt` が想定どおり配信されることを目視確認
- [ ] CI (build-check / chromatic) パス

## 見てほしいところ

- [ ] H2 セクション分割の粒度: `## リンク` / `## ドキュメント` / `## ソースコード` / `## Optional` の 4 区分は妥当か
- [ ] リンク選定: 本番環境・GitHub・README・LICENSE・`.apm/instructions/*` 3 本・主要ソース 5 本・SECURITY・workflows の計 12 本で過不足ないか
- [ ] 詳細セクション (機能・技術スタック) を H2 から bold ラベル + リストへ降格した表現の可否
- [ ] 各リンクに付した注記文言 (例: 「公開デプロイ。ブラウザで開くとそのまま利用可能」) の精度