### PR TITLE
chore(iac/hosting): Vercel project / team の追加属性を明示宣言

### DIFF
--- a/iac/hosting/project.tf
+++ b/iac/hosting/project.tf
@@ -1,6 +1,7 @@
 # Web Analytics / Speed Insights は @vercel/analytics と @vercel/speed-insights の SDK で
-# application/src/app/layout.tsx に組み込み済み。Vercel provider 5.3.x には対応する project
-# 属性が無いため、トグル状態は IaC で固定できない (Hobby plan は Vercel 側で自動有効)。
+# application/src/app/layout.tsx に組み込み済み。vercel/vercel provider v5 (lock: 5.3.0) に
+# 対応する project 属性が無いため、トグル状態は IaC で固定できない (Hobby plan は Vercel
+# 側で自動有効)。
 resource "vercel_project" "bingo_next" {
   root_directory = "application/"
   framework      = "nextjs"

--- a/iac/hosting/project.tf
+++ b/iac/hosting/project.tf
@@ -1,7 +1,11 @@
+# Web Analytics / Speed Insights は @vercel/analytics と @vercel/speed-insights の SDK で
+# application/src/app/layout.tsx に組み込み済み。Vercel provider 5.3.x には対応する project
+# 属性が無いため、トグル状態は IaC で固定できない (Hobby plan は Vercel 側で自動有効)。
 resource "vercel_project" "bingo_next" {
   root_directory = "application/"
   framework      = "nextjs"
   name           = "bingo-next"
+  node_version   = "24.x"
 
   git_repository = {
     production_branch = local.production_branch
@@ -16,6 +20,20 @@ resource "vercel_project" "bingo_next" {
   vercel_authentication = {
     deployment_type = "standard_protection"
   }
+
+  auto_assign_custom_domains                        = true
+  automatically_expose_system_environment_variables = false
+  customer_success_code_visibility                  = false
+  directory_listing                                 = false
+  enable_affected_projects_deployments              = false
+  enable_preview_feedback                           = true
+  enable_production_feedback                        = true
+  function_failover                                 = true
+  git_fork_protection                               = true
+  git_lfs                                           = false
+  preview_deployments_disabled                      = false
+  prioritise_production_builds                      = false
+  public_source                                     = false
 }
 
 resource "vercel_project_domain" "bingo_next" {

--- a/iac/hosting/team.tf
+++ b/iac/hosting/team.tf
@@ -9,4 +9,6 @@ resource "vercel_team_config" "bingo_next" {
   }
   hide_ip_addresses               = true
   hide_ip_addresses_in_log_drains = true
+  enable_preview_feedback         = "default"
+  enable_production_feedback      = "default"
 }


### PR DESCRIPTION
## Summary
- `vercel_project` / `vercel_team_config` の既定値を Vercel UI デフォルト値で明示宣言し、TFC plan で drift を検出できるようにする
- Pro 限定機能（WAF custom rules / log drain / webhook / trusted_ips / password_protection / deployment_retention）は Hobby plan のため対象外（将来 Pro 移行時に追加）
- Analytics / Speed Insights は `@vercel/analytics` / `@vercel/speed-insights` SDK で `application/src/app/layout.tsx` に組込済み。Vercel provider 5.3.x には対応する project 属性が存在しないため、IaC では制約をコメントで明記するに留める

## 追加した属性
### `vercel_project`
- `node_version = "24.x"` — `application/package.json` の volta (node 24.11.0) と整合
- `auto_assign_custom_domains = true`
- `automatically_expose_system_environment_variables = false`
- `customer_success_code_visibility = false`
- `directory_listing = false`
- `enable_affected_projects_deployments = false`
- `enable_preview_feedback = true`
- `enable_production_feedback = true`
- `function_failover = true`
- `git_fork_protection = true` — OSS リポジトリでの重要設定
- `git_lfs = false`
- `preview_deployments_disabled = false`
- `prioritise_production_builds = false`
- `public_source = false`

### `vercel_team_config`
- `enable_preview_feedback = "default"`
- `enable_production_feedback = "default"`

## Test plan
- [ ] TFC workspace `bingo_next/hosting` でこのブランチに対して `terraform plan` を実行
- [ ] 想定外の差分（特に node_version, enable_*_feedback, git_fork_protection）が出ないか確認
- [ ] drift が出た属性は値を実状に合わせて修正し再 plan
- [ ] apply 後、Vercel project / team の設定 UI で同等の値が維持されていることを確認

## Out of scope
- Pro 限定機能の IaC 化（Pro 移行時に別 PR）
- `vercel_project_environment_variable` → `vercel_project_environment_variables` (複数形) への移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)