### PR TITLE
chore(prettier): 設定を参照リポに整合し lint-staged を改善

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -37,9 +37,15 @@
 		}
 	},
 	"lint-staged": {
-		"*.{mjs,ts,tsx}": [
-			"pnpm exec eslint . --fix",
-			"pnpm exec prettier --write ."
+		"*.{ts,tsx,mjs,cjs}": [
+			"pnpm exec eslint --fix",
+			"pnpm exec prettier --write"
+		],
+		"*.{html,css,json,md}": [
+			"pnpm exec prettier --write"
+		],
+		"!(pnpm-lock).{yml,yaml}": [
+			"pnpm exec prettier --write"
 		]
 	},
 	"prettier": {
@@ -49,19 +55,19 @@
 		"semi": false,
 		"singleQuote": false,
 		"quoteProps": "as-needed",
-		"jsxSingleQuote": false,
-		"trailingComma": "es5",
+		"trailingComma": "all",
 		"bracketSpacing": false,
+		"bracketSameLine": false,
 		"arrowParens": "avoid",
-		"rangeStart": 0,
-		"rangeEnd": 10000,
-		"filepath": "none",
 		"requirePragma": false,
 		"insertPragma": false,
-		"proseWrap": "never",
-		"htmlWhitespaceSensitivity": "ignore",
-		"vueIndentScriptAndStyle": true,
-		"endOfLine": "auto"
+		"proseWrap": "always",
+		"htmlWhitespaceSensitivity": "css",
+		"singleAttributePerLine": false,
+		"embeddedLanguageFormatting": "auto",
+		"objectWrap": "preserve",
+		"experimentalOperatorPosition": "end",
+		"endOfLine": "lf"
 	},
 	"dependencies": {
 		"@radix-ui/react-slot": "^1.2.4",

--- a/application/vitest.config.ts
+++ b/application/vitest.config.ts
@@ -87,5 +87,5 @@ export default defineConfig(
 				provider: playwright(),
 			},
 		},
-	}))
+	})),
 )


### PR DESCRIPTION
## 期待する挙動・状態

- [ROhta/bingo](https://github.com/ROhta/bingo/blob/main/package.json) の prettier 設定と完全に一致させる
- lint-staged は per-staged-file 形式で動作し、`pnpm-lock.yaml` を整形対象から除外する
- `trailingComma:"all"` などの新ルール下で全ソースが整形済み状態を維持する

## 確認済み項目

- [x] `npx prettier --check` (src/storybook/configs 全体) → green
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx eslint .` → 0 errors
- [x] `npx next build` → success
- [x] `git commit` 時の husky → lint-staged が新パターンで正常動作 (staged 1 file のみ処理)
- [x] `pnpm-lock.yaml` が prettier の影響を受けないことを確認

## 見てほしいところ

- [ ] **prettier 設定の差分** (`application/package.json`)
  - 廃止/不要オプション削除: `jsxSingleQuote` / `rangeStart` / `rangeEnd` / `filepath` / `vueIndentScriptAndStyle`
  - 新規オプション追加: `bracketSameLine:false` / `singleAttributePerLine:false` / `embeddedLanguageFormatting:"auto"` / `objectWrap:"preserve"` / `experimentalOperatorPosition:"end"`
  - 値変更: `trailingComma "es5"→"all"` / `proseWrap "never"→"always"` / `htmlWhitespaceSensitivity "ignore"→"css"` / `endOfLine "auto"→"lf"`
- [ ] **lint-staged の再設計** (参照リポ準拠の per-staged-file パターン)
  - `*.{ts,tsx,mjs,cjs}` → eslint --fix + prettier --write (`.` グロブを削除し staged path 引数のみ)
  - `*.{html,css,json,md}` → prettier --write
  - `!(pnpm-lock).{yml,yaml}` → prettier --write (lockfile を明示除外)
- [ ] **ソースコード変更** (`application/vitest.config.ts`)
  - `trailingComma:"all"` により `defineConfig(...)` の閉じ括弧前に末尾カンマを 1 ヶ所追加 (動作不変)