### PR TITLE
ci(dependabot): auto-merge を完成させる approve ステップと CODEOWNERS 拡張を追加

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,7 @@ README.md @ROhta
 .github/dependabot.yml
 application/package.json
 application/pnpm-lock.yaml
+.github/workflows/*.yml
+.github/actions/*/action.yml
+iac/**/*.tf
+iac/**/.terraform.lock.hcl

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   auto-merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.sender.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,13 +1,11 @@
 name: Auto Merge
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  pull_request_target:
 
 jobs:
   auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -16,6 +14,20 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1.0.2-beta9
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      - name: Approve PR
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)" = "APPROVED" ]; then
+            echo "PR already approved, skipping."
+          else
+            gh pr review --approve "$PR_URL"
+          fi
       - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
         with:
           use-github-auto-merge: true


### PR DESCRIPTION
## 期待する挙動・状態

- Dependabot が作成した PR について `dependabot-merge.yml` 内の `gh pr review --approve` が 1 件目の approval を提供し、既存の `fastify/github-action-merge-dependabot` (use-github-auto-merge: true) と合わせて `production ready` ruleset の `required_approving_review_count: 1` を満たして自動マージされる
- `require_code_owner_review: true` も CODEOWNERS の除外行に terraform / composite action / workflow yml を追加することでスキップされ、npm に加えて terraform / github-actions の Dependabot PR も手動レビューなしで auto-merge する
- semver-major bump は `dependabot/fetch-metadata` の出力で approve をスキップ + 既存 `fastify` action の `target: "minor"` ガードと二重に弾き、引き続き手動レビューを要求する
- 過去 20 件すべて `ROhta` 本人が手動マージしていた状態 (`mergedBy.is_bot: false`) を解消する

## 確認済み項目

- [x] YAML 構文: `python3 -c "import yaml; yaml.safe_load(...)"` OK
- [x] actionlint: `docker run rhysd/actionlint` 実行、exit 0
- [x] `gh api repos/.../actions/permissions/workflow` → `can_approve_pull_request_reviews: true` を確認 (これが false だと approve 403 で全停止する)
- [x] `gh api repos/.../codeowners/errors?ref=<branch>` → `[]` (パターン構文エラーなし)
- [x] `dependabot/fetch-metadata` を `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (v3.1.0) で SHA pin
- [x] `github.event.pull_request.html_url` は `env: PR_URL: ...` 経由で参照する script injection 安全パターン
- [x] CODEOWNERS の追加パターンが現状の Dependabot 更新ファイル (`iac/hosting/main.tf`, `iac/hosting/.terraform.lock.hcl`, `.github/workflows/*.yml`, `.github/actions/setup-node-pnpm/action.yml`) を網羅
- [ ] **実機検証**: 次回 Dependabot PR が動くまで auto-merge の発火は確認できない (npm は daily 10:00 JST / terraform 金曜 / github-actions 木曜)。マージ後の初回 Dependabot PR を smoke test として観察すること

## 見てほしいところ

- **CODEOWNERS 拡張のトレードオフ**: `.github/workflows/*.yml` を所有者なしに変更したため、手動 PR で `chromatic.yml` 等の workflow を編集しても code-owner 承認が不要になる。Build-Check / Snyk x2 / Dependency-Review / triage の必須 status check は残っているが、Dependabot 自動化の利益と引き換えにこの穴を許容する判断で良いか
- **`pull_request_target` 化**: Dependabot 公式 (`dependabot/fetch-metadata` README) が推奨する形に揃えた。`pull_request` だと Dependabot トリガ時は read-only token になるため。fork からの悪意ある書き換えに弱くなる典型的懸念は、Dependabot PR が同一 repo 内なので該当しない
- **`on: push: branches: main` の削除**: 既存 workflow に書かれていたが、`fastify/github-action-merge-dependabot` は PR イベントでしか動作しないため死に trigger だった。意図があれば差し戻す
- **CODEOWNERS の追加位置**: 末尾に並べた。CODEOWNERS は「最後にマッチした行が優先」なので、追加行が `.github/ @ROhta` `iac/ @ROhta` 等の基本ルールより下にあれば確実に上書きされる