### PR TITLE
refactor(button): React 19 の ref-as-prop パターンに移行

### DIFF
--- a/application/src/components/ui/button.tsx
+++ b/application/src/components/ui/button.tsx
@@ -1,9 +1,10 @@
-import * as React from "react"
 import {Slot} from "@radix-ui/react-slot"
 import {cva, type VariantProps} from "class-variance-authority"
-import type {ClassValue} from "clsx"
 
 import {cn} from "@/lib/utils"
+
+import type {ClassValue} from "clsx"
+import type {ComponentProps, JSX, Ref} from "react"
 
 type ButtonVariantsProps = {
 	variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link" | null | undefined
@@ -34,14 +35,15 @@ const buttonVariants: (props?: ButtonVariantsProps) => string = cva("inline-flex
 	},
 })
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
-	asChild?: boolean
-}
+export type ButtonProps = ComponentProps<"button"> &
+	VariantProps<typeof buttonVariants> & {
+		asChild?: boolean
+		ref?: Ref<HTMLButtonElement>
+	}
 
-const Button: React.ForwardRefExoticComponent<ButtonProps & React.RefAttributes<HTMLButtonElement>> = React.forwardRef<HTMLButtonElement, ButtonProps>(({className, variant, size, asChild = false, ...props}, ref) => {
+const Button = ({className, variant, size, asChild = false, ref, ...props}: ButtonProps): JSX.Element => {
 	const Comp = asChild ? Slot : "button"
 	return <Comp className={cn(buttonVariants({variant, size, className}))} ref={ref} {...props} />
-})
-Button.displayName = "Button"
+}
 
 export {Button, buttonVariants}


### PR DESCRIPTION
## 期待する挙動・状態

- `Button` コンポーネントが React 19 の ref-as-prop パターンで動作する (`React.forwardRef` を撤廃)
- 既存利用箇所 (`control-buttons.tsx` / `Button.stories.ts`) は挙動・型ともに不変
- `pnpm run lint` / `pnpm run build` / `pnpm run build-storybook` がすべて pass

## 確認済み項目

- [x] `pnpm run lint` が pass
- [x] `pnpm run build` (Next.js 16 + tsc strict + isolatedDeclarations) が pass
- [x] `pnpm run build-storybook` が pass
- [x] `Button` の既存呼び出し元 (`control-buttons.tsx`, `Button.stories.ts`) が型エラーなく動作
- [x] `@radix-ui/react-slot` (^1.2.4) の `Slot` は `ref` を通常 prop として受け付けるため `asChild` 経路でも壊れない

## 見てほしいところ

- [ ] `ButtonProps` を `ComponentProps<"button"> & VariantProps<...> & { asChild?: boolean; ref?: Ref<HTMLButtonElement> }` の type alias に変更しました。`React.ButtonHTMLAttributes<HTMLButtonElement>` extends → `ComponentProps<"button">` の置換は React 19 推奨パターンですが、interface → type alias 化に伴う宣言マージ不能化の影響範囲に懸念がないかご確認ください (現状リポ内に `ButtonProps` を拡張する箇所はありません)
- [ ] `Button.displayName = "Button"` を削除しました。function component の `name` で自動付与されるため Storybook / React DevTools 表示は変わりませんが、念のため
- [ ] `isolatedDeclarations: true` のため戻り値型に `JSX.Element` を明示しています。`import type {JSX} from "react"` の named import が `verbatimModuleSyntax: true` 配下で他ファイルとも整合するか