### PR TITLE
refactor(config): tsconfig 整理と Next.js 16 typedRoutes 有効化

### DIFF
--- a/application/next.config.ts
+++ b/application/next.config.ts
@@ -1,7 +1,7 @@
 import type {NextConfig} from "next"
 
 const nextConfig: NextConfig = {
-	/* config options here */
+	typedRoutes: true,
 }
 
 export default nextConfig

--- a/application/tsconfig.json
+++ b/application/tsconfig.json
@@ -1,5 +1,4 @@
 {
-	"compileOnSave": true,
 	"extends": "@tsconfig/strictest/tsconfig.json",
 	"compilerOptions": {
 		"target": "ES2022",
@@ -28,7 +27,6 @@
 		"removeComments": true,
 		"noEmitOnError": true,
 		"checkJs": false,
-		"experimentalDecorators": true,
 		"plugins": [
 			{
 				"name": "next"


### PR DESCRIPTION
## 期待する挙動・状態

- `tsconfig.json` から実効性のないオプションを削除し、設定をスリム化する
  - `compileOnSave`: tsserver 内部 flag のため Next.js 16 / VSCode では意味なし
  - `experimentalDecorators`: リポ全体で未使用
- `next.config.ts` で Next.js 16 で stable になった `typedRoutes` を有効化し、`Link` などのルート文字列が型安全になるようにする
- `@tsconfig/strictest` 由来の strict 系オプション (`isolatedDeclarations`, `verbatimModuleSyntax`, `erasableSyntaxOnly`, `noUncheckedSideEffectImports`) と `ignoreDeprecations: "6.0"` は維持

## 確認済み項目

- [x] `pnpm install --frozen-lockfile` が成功すること
- [x] `pnpm run lint` が pass すること
- [x] `pnpm run build` が pass し、`Next.js 16.2.6` で TypeScript チェックも通ること
- [x] `typedRoutes` 有効化により `.next/types/routes.d.ts` が生成されることを確認
- [x] `package.json` は触っていないこと

## 見てほしいところ

- [ ] `tsconfig.json` から `compileOnSave` / `experimentalDecorators` を削除した影響に懸念がないか (リポ内に decorator 構文の利用がないことは確認済み)
- [ ] `next.config.ts` で `typedRoutes: true` を有効化したことによるリンク型エラーが他箇所で発生していないか (今回の build では未検出)