### PR TITLE
refactor(layout): head のベタ書きを Next.js Metadata API に集約

### DIFF
--- a/application/src/app/layout.tsx
+++ b/application/src/app/layout.tsx
@@ -4,24 +4,26 @@ import {SpeedInsights} from "@vercel/speed-insights/next"
 
 import {medievalSharp} from "@/app/fonts"
 
+import type {Metadata} from "next"
 import type {JSX, ReactNode} from "react"
 
-export const metadata = {
+export const metadata: Metadata = {
+	metadataBase: new URL("https://rohta-bingo-next.vercel.app/"),
 	title: "Bingo",
 	description: "ビンゴアプリケーション",
+	icons: {icon: "/logo.ico"},
+	openGraph: {
+		title: "Bingo",
+		description: "ビンゴアプリケーション",
+		images: "/ogp.png",
+		url: "https://rohta-bingo-next.vercel.app/",
+		type: "website",
+	},
 }
 
 export default function RootLayout({children}: {children: ReactNode}): JSX.Element {
 	return (
 		<html lang="ja">
-			<head>
-				<link rel="icon" href="/logo.ico" />
-				<meta property="description" content="ビンゴアプリケーション" />
-				<meta property="og:title" content="Bingo" />
-				<meta property="og:image" content="/ogp.png" />
-				<meta property="og:url" content="https://rohta-bingo-next.vercel.app/" />
-				<meta property="og:type" content="website" />
-			</head>
 			<body className={`${medievalSharp.className} bg-gray-900 text-white`}>
 				{children}
 				<Analytics />

--- a/application/src/app/layout.tsx
+++ b/application/src/app/layout.tsx
@@ -7,8 +7,10 @@ import {medievalSharp} from "@/app/fonts"
 import type {Metadata} from "next"
 import type {JSX, ReactNode} from "react"
 
+const siteUrl = new URL("https://rohta-bingo-next.vercel.app/")
+
 export const metadata: Metadata = {
-	metadataBase: new URL("https://rohta-bingo-next.vercel.app/"),
+	metadataBase: siteUrl,
 	title: "Bingo",
 	description: "ビンゴアプリケーション",
 	icons: {icon: "/logo.ico"},
@@ -16,7 +18,7 @@ export const metadata: Metadata = {
 		title: "Bingo",
 		description: "ビンゴアプリケーション",
 		images: "/ogp.png",
-		url: "https://rohta-bingo-next.vercel.app/",
+		url: siteUrl,
 		type: "website",
 	},
 }


### PR DESCRIPTION
## 期待する挙動・状態

- `RootLayout` 内の `<head>` 直書き `<meta>` / `<link>` を排除し、Next.js の Metadata API (`export const metadata: Metadata = { ... }`) に集約する
- favicon / OGP / description が Metadata API 経由で同等以上の HTML として出力される
- `metadataBase` を設定し、`openGraph.images` 等の相対パスがビルド時に絶対 URL へ正しく解決され、Next.js の `metadataBase property in metadata export is not set` 警告も解消される

## 確認済み項目

- [x] `pnpm run lint` がエラー・警告ゼロで通る
- [x] `pnpm run build` が成功し、`metadataBase` 警告も含めて Metadata 関連の警告が出ない
- [x] `pnpm run dev` 起動後の `curl http://localhost:3060` で次のタグが描画されることを確認
  - `<title>Bingo</title>`
  - `<meta name="description" content="ビンゴアプリケーション"/>`
  - `<meta property="og:title" content="Bingo"/>`
  - `<meta property="og:description" content="ビンゴアプリケーション"/>`
  - `<meta property="og:url" content="https://rohta-bingo-next.vercel.app"/>`
  - `<meta property="og:image" content="https://rohta-bingo-next.vercel.app/ogp.png"/>` (相対 `/ogp.png` が `metadataBase` で絶対化されることを確認)
  - `<meta property="og:type" content="website"/>`
  - `<link rel="icon" href="/logo.ico"/>`

## 見てほしいところ

- [ ] 旧コードでは `<meta property="description" ...>` (本来は `name="description"`) という非標準属性で description を埋めていたが、Metadata API 化に伴い `<meta name="description">` + `<meta property="og:description">` (Next.js が `openGraph.description` から自動付与) という 2 本立てに置き換わっている点。OGP description が新規追加扱いになるため意図と合っているか確認をお願いします
- [ ] `metadataBase` を `https://rohta-bingo-next.vercel.app/` に固定して警告を消した方針について。プレビュー環境用に環境変数等から動的解決したい場合は別途指示ください
- [ ] `description` / `openGraph.title` 等の重複文字列を Metadata 内に二重で書いているのは Next.js Metadata の仕様 (`openGraph.title` 未指定時は `title` を継承するが、開発体験の明示性のため敢えて指定) に合わせています。集約したい場合は relabel します