### PR TITLE
refactor(vitest): next/font モック重複を整理し use-audio.test の non-null 断言を解消

### DIFF
--- a/application/src/__tests__/hooks/use-audio.test.ts
+++ b/application/src/__tests__/hooks/use-audio.test.ts
@@ -56,11 +56,14 @@ describe("useAudio hook", () => {
 		result.current.playDrumroll(onEndedMock)
 
 		// 最新のインスタンスを使用
-		const drumrollInstance = audioInstances[0]!
-		expect(drumrollInstance.currentTime).toBe(0)
+		const [drumroll] = audioInstances
+		expect(drumroll).toBeDefined()
+		if (!drumroll) return
+
+		expect(drumroll.currentTime).toBe(0)
 		// onendedの検証方法を変更
-		expect(drumrollInstance.onended).not.toBeNull()
-		expect(drumrollInstance.play).toHaveBeenCalled()
+		expect(drumroll.onended).not.toBeNull()
+		expect(drumroll.play).toHaveBeenCalled()
 	})
 
 	it("stopDrumroll should pause drumroll audio and reset currentTime", () => {
@@ -69,9 +72,12 @@ describe("useAudio hook", () => {
 		result.current.stopDrumroll()
 
 		// drumrollのAudioインスタンスのメソッドが正しく呼ばれたか確認
-		const drumrollInstance = audioInstances[0]!
-		expect(drumrollInstance.pause).toHaveBeenCalled()
-		expect(drumrollInstance.currentTime).toBe(0)
+		const [drumroll] = audioInstances
+		expect(drumroll).toBeDefined()
+		if (!drumroll) return
+
+		expect(drumroll.pause).toHaveBeenCalled()
+		expect(drumroll.currentTime).toBe(0)
 	})
 
 	it("playCymbals should play cymbals audio", () => {
@@ -80,9 +86,12 @@ describe("useAudio hook", () => {
 		result.current.playCymbals()
 
 		// cymbalsのAudioインスタンスのメソッドが正しく呼ばれたか確認
-		const cymbalsInstance = audioInstances[1]!
-		expect(cymbalsInstance.currentTime).toBe(0)
-		expect(cymbalsInstance.play).toHaveBeenCalled()
+		const [, cymbals] = audioInstances
+		expect(cymbals).toBeDefined()
+		if (!cymbals) return
+
+		expect(cymbals.currentTime).toBe(0)
+		expect(cymbals.play).toHaveBeenCalled()
 	})
 
 	it("should cleanup audio elements on unmount", () => {
@@ -91,9 +100,12 @@ describe("useAudio hook", () => {
 		unmount()
 
 		// アンマウント時に両方のAudioインスタンスのpauseが呼ばれたか確認
-		const drumrollInstance = audioInstances[0]!
-		const cymbalsInstance = audioInstances[1]!
-		expect(drumrollInstance.pause).toHaveBeenCalled()
-		expect(cymbalsInstance.pause).toHaveBeenCalled()
+		const [drumroll, cymbals] = audioInstances
+		expect(drumroll).toBeDefined()
+		expect(cymbals).toBeDefined()
+		if (!drumroll || !cymbals) return
+
+		expect(drumroll.pause).toHaveBeenCalled()
+		expect(cymbals.pause).toHaveBeenCalled()
 	})
 })

--- a/application/vitest.config.ts
+++ b/application/vitest.config.ts
@@ -7,14 +7,12 @@ import {defineConfig, type Plugin, type ViteUserConfigExport} from "vitest/confi
 
 const dirname = typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url))
 
-// Vite plugin to handle sb-original and next/font imports
+// Vite plugin to resolve `sb-original/*` virtual modules emitted by Storybook's Next.js preset.
+// `next/font/*` は resolve.alias で `.storybook/mocks/next-font.js` に解決されるため、ここでは扱わない。
 const storybookOriginalPlugin = (): Plugin => ({
 	name: "storybook-original-resolver",
 	resolveId(id) {
 		if (id.startsWith("sb-original/")) {
-			return `\0${id}`
-		}
-		if (id === "next/font/google" || id === "next/font/local") {
 			return `\0${id}`
 		}
 		return null
@@ -23,22 +21,6 @@ const storybookOriginalPlugin = (): Plugin => ({
 		if (id.startsWith("\0sb-original/")) {
 			const moduleName = id.slice(1).replace("sb-original/", "")
 			return `export const ${moduleName.replace(/-/g, "_")} = {}; export default {};`
-		}
-		if (id === "\0next/font/google" || id === "\0next/font/local") {
-			return `
-				const mockFont = () => ({ className: '', style: {} });
-				export default mockFont;
-				export const MedievalSharp = mockFont;
-				const handler = {
-					get: (target, prop) => {
-						if (prop === '__esModule') return true;
-						if (prop === 'default') return mockFont;
-						return mockFont;
-					}
-				};
-				const proxy = new Proxy({}, handler);
-				export { proxy };
-			`
 		}
 		return null
 	},
@@ -53,9 +35,6 @@ const config: ViteUserConfigExport = defineConfig(
 		},
 	}).then(plugins => ({
 		plugins: [...plugins, storybookOriginalPlugin()],
-		optimizeDeps: {
-			exclude: ["next/font/google", "next/font/local"],
-		},
 		resolve: {
 			alias: {
 				"@": path.resolve(dirname, "./src"),


### PR DESCRIPTION
## 期待する挙動・状態

- `application/vitest.config.ts` の `next/font` モック重複を整理し、`resolve.alias` 一本で `.storybook/mocks/next-font.js` に解決する構成に統一する。
- `storybookOriginalPlugin` は Storybook が出す `sb-original/*` 仮想モジュール解決のみを担当する形に削ぎ落とす。
- `application/src/__tests__/hooks/use-audio.test.ts` の `audioInstances[n]!` non-null 断言を取り除き、`@tsconfig/strictest` の `noUncheckedIndexedAccess: true` 下でも安全に動作する形に書き換える。
- テストの意図 (initialize / playDrumroll / stopDrumroll / playCymbals / cleanup) と、Storybook test / Vitest 単体テストの動作は変更しない。

## 確認済み項目

- [x] `pnpm run lint` が pass
- [x] `pnpm run build` が pass (Next.js 16 / TypeScript)
- [x] `pnpm exec vitest run --no-coverage` が pass (Storybook test 4 件すべて成功)
- [x] `application/.storybook/mocks/next-font.js` は変更不要 (alias 経由の mock として継続利用)

## 見てほしいところ

- [ ] `vitest.config.ts` で `next/font` 解決を `resolve.alias` 一本に寄せた点。`storybookOriginalPlugin` 内の `resolveId` / `load` から `next/font/*` 分岐を削除し、`optimizeDeps.exclude` も削除した。`sb-original/*` の仮想モジュール処理は維持している。
- [ ] `use-audio.test.ts` の non-null 断言除去パターン。`const [drumroll] = audioInstances` → `expect(drumroll).toBeDefined()` → `if (!drumroll) return` で type narrowing を行い、それ以降は安全にアクセスできる形にしている。テスト本文の assertion は元の挙動と等価。