### PR TITLE
refactor(components): JSX.Element を React.JSX.Element に置換し index key を解消

### DIFF
--- a/application/src/components/control-buttons.tsx
+++ b/application/src/components/control-buttons.tsx
@@ -1,6 +1,6 @@
 import {Button} from "@/components/ui/button"
 
-import type {JSX} from "react"
+import type React from "react"
 
 interface ControlButtonsProps {
 	isRunning: boolean
@@ -8,7 +8,7 @@ interface ControlButtonsProps {
 	onReset: () => void
 }
 
-export const ControlButtons = ({isRunning, onStart, onReset}: ControlButtonsProps): JSX.Element => {
+export const ControlButtons = ({isRunning, onStart, onReset}: ControlButtonsProps): React.JSX.Element => {
 	return (
 		<div className="flex gap-0">
 			<Button onClick={onStart} className="bg-slate-700 px-20 py-10 rounded-xl text-3xl">

--- a/application/src/components/hit-numbers.tsx
+++ b/application/src/components/hit-numbers.tsx
@@ -1,16 +1,16 @@
-import type {JSX} from "react"
+import type React from "react"
 
 interface HitNumbersProps {
 	numbers: string[]
 }
 
-export const HitNumbers = ({numbers}: HitNumbersProps): JSX.Element => {
+export const HitNumbers = ({numbers}: HitNumbersProps): React.JSX.Element => {
 	return (
 		<div className="p-4">
 			<h2 className="text-6xl py-10">Hit Numbers</h2>
 			<div className="grid grid-cols-6 gap-2">
-				{numbers.map((number, index) => (
-					<div key={index} className="text-6xl py-10">
+				{numbers.map(number => (
+					<div key={number} className="text-6xl py-10">
 						{number}
 					</div>
 				))}

--- a/application/src/components/number-display.tsx
+++ b/application/src/components/number-display.tsx
@@ -1,11 +1,9 @@
-import type {JSX} from "react"
+import type React from "react"
 
-export const NumberDisplay = ({number}: {number: string}): JSX.Element => {
+export const NumberDisplay = ({number}: {number: string}): React.JSX.Element => {
 	return (
 		<div className="flex">
-			<div style={{fontSize: "55vmin"}} className="font-bold">
-				{number}
-			</div>
+			<div className="font-bold text-[55vmin]">{number}</div>
 		</div>
 	)
 }


### PR DESCRIPTION
## 期待する挙動・状態

- React 19 で deprecated となった global `JSX` namespace への依存を排除し、`import type React from "react"` + `React.JSX.Element` を戻り値型に統一する
- `hit-numbers.tsx` の React key を array index ではなく一意な値 (表示する番号文字列) に変更し、index key アンチパターンを解消する
- `number-display.tsx` の inline `style={{fontSize: "55vmin"}}` を Tailwind 任意値クラス `text-[55vmin]` に置き換え、スタイル指定を `className` に集約する
- UI の見た目および挙動は不変

## 確認済み項目

- [x] `pnpm run lint` が pass
- [x] `pnpm run build` (Next.js 16 / Turbopack) が pass
- [x] `pnpm run dev` で起動した dev server に `curl` で疎通確認 (200 応答)
- [x] `application/src/hooks/use-bingo.ts` の `selectNumber` が `do...while (selectedNumbers.includes(newNumber))` で重複排除しているため、`key={number}` のユニーク性が保証されることをコードリーディングで確認
- [x] 既存の Storybook story (`hit-numbers.stories.ts` / `number-display.stories.ts` / `control-buttons.stories.ts`) に渡される props 型は変更なし

## 見てほしいところ

- [ ] `import type React from "react"` + `React.JSX.Element` という記法でよいか (`import type {JSX} from "react"` + `JSX.Element` のままにすべきか)。本リポジトリの他のファイル (`page.tsx` / `layout.tsx`) ではまだ後者の表記が残っているため、別 PR で揃える想定
- [ ] `text-[55vmin]` 置換による font-size の最終計算値が `style={{fontSize: "55vmin"}}` と完全に一致するか (Tailwind v4 の arbitrary value 解釈)