### PR TITLE
refactor(hooks): UseBingo を useBingo にリネームし周辺参照を更新

### DIFF
--- a/application/src/__tests__/hooks/use-bingo.test.ts
+++ b/application/src/__tests__/hooks/use-bingo.test.ts
@@ -1,7 +1,7 @@
 import {renderHook, act} from "@testing-library/react"
 import {describe, it, expect, vi, beforeEach, afterEach} from "vitest"
 
-import {UseBingo} from "@/hooks/use-bingo"
+import {useBingo} from "@/hooks/use-bingo"
 
 // useAudioのモック
 vi.mock("@/hooks/use-audio", () => ({
@@ -17,7 +17,7 @@ vi.mock("@/hooks/use-audio", () => ({
 	}),
 }))
 
-describe("UseBingo", () => {
+describe("useBingo", () => {
 	// テスト前に実行
 	beforeEach(() => {
 		// Math.randomのモック
@@ -37,7 +37,7 @@ describe("UseBingo", () => {
 
 	describe("generateNumber", () => {
 		it("0から75までの数字をランダムに生成し、2桁の文字列として返す", () => {
-			const {result} = renderHook(() => UseBingo())
+			const {result} = renderHook(() => useBingo())
 
 			// Math.randomが0.5を返すようにモック化されているので、
 			// 0.5 * 76 = 38が生成される
@@ -47,7 +47,7 @@ describe("UseBingo", () => {
 
 	describe("startRotation", () => {
 		it("回転を開始し、isRunningをtrueに設定する", () => {
-			const {result} = renderHook(() => UseBingo())
+			const {result} = renderHook(() => useBingo())
 
 			act(() => {
 				result.current.startRotation()
@@ -59,7 +59,7 @@ describe("UseBingo", () => {
 
 	describe("reset", () => {
 		it("確認ダイアログでYesを選択した場合、状態をリセットする", () => {
-			const {result} = renderHook(() => UseBingo())
+			const {result} = renderHook(() => useBingo())
 
 			// リセット
 			act(() => {

--- a/application/src/app/page.tsx
+++ b/application/src/app/page.tsx
@@ -3,12 +3,12 @@
 import {ControlButtons} from "@/components/control-buttons"
 import {HitNumbers} from "@/components/hit-numbers"
 import {NumberDisplay} from "@/components/number-display"
-import {UseBingo} from "@/hooks/use-bingo"
+import {useBingo} from "@/hooks/use-bingo"
 
 import type {JSX} from "react"
 
 export default function Home(): JSX.Element {
-	const {currentNumber, selectedNumbers, isRunning, startRotation, reset} = UseBingo()
+	const {currentNumber, selectedNumbers, isRunning, startRotation, reset} = useBingo()
 
 	return (
 		<main className="min-h-screen">

--- a/application/src/hooks/use-bingo.ts
+++ b/application/src/hooks/use-bingo.ts
@@ -12,11 +12,11 @@ type UseBingoReturn = {
 	reset: () => void
 }
 
-export const UseBingo = (): UseBingoReturn => {
+export const useBingo = (): UseBingoReturn => {
 	const [currentNumber, setCurrentNumber] = useState("00")
 	const [selectedNumbers, setSelectedNumbers] = useState<string[]>([])
 	const [isRunning, setIsRunning] = useState(false)
-	const intervalRef = useRef<NodeJS.Timeout>(null)
+	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 	const {playDrumroll, stopDrumroll, playCymbals} = useAudio()
 
 	const generateNumber = useCallback(() => {

--- a/application/src/stories/control-buttons.stories.ts
+++ b/application/src/stories/control-buttons.stories.ts
@@ -1,7 +1,6 @@
 import {fn} from "storybook/test"
 
 import {ControlButtons} from "@/components/control-buttons"
-import {UseBingo} from "@/hooks/use-bingo"
 
 import type {Meta, StoryObj} from "@storybook/nextjs-vite"
 
@@ -25,7 +24,5 @@ type Story = StoryObj<typeof meta>
 export const control_buttons: Story = {
 	args: {
 		isRunning: false,
-		onStart: () => UseBingo().startRotation(),
-		onReset: () => UseBingo().reset(),
 	},
 }


### PR DESCRIPTION
## 期待する挙動・状態

- React Hook 命名規約 (lowerCamelCase) に従い `UseBingo` を `useBingo` にリネーム
- `useRef<NodeJS.Timeout>(null)` をブラウザ/Node 両環境互換の `useRef<ReturnType<typeof setInterval> | null>(null)` に変更
- `control-buttons.stories.ts` で React Hook をコンポーネント外から呼んでいたアンチパターン (`() => UseBingo().startRotation()`) を解消。meta 側の `fn()` モックに統一
- 既存挙動 (start/stop/reset/数字回転/音/Math.random / 76 上限) は一切変更なし

## 確認済み項目

- [x] `pnpm run lint` 成功
- [x] `pnpm run build` 成功 (Next.js 16 / Turbopack)
- [x] `pnpm exec vitest run` 全 4 件成功
- [x] `pnpm run dev` で `curl http://localhost:300x` が `00` 表示と START/RESET ボタンを含む HTML を返すことを確認
- [x] `grep UseBingo application/src/` の残存は型エイリアス `UseBingoReturn` のみ (型は PascalCase が正)

## 見てほしいところ

- [ ] `application/src/hooks/use-bingo.ts` の `intervalRef` 型変更で副作用が無いか (テストの `setInterval` モック `123 as unknown as NodeJS.Timeout` と互換性が取れているか)
- [ ] `application/src/stories/control-buttons.stories.ts` で story-level の `onStart`/`onReset` を削除し meta の `fn()` に任せた挙動が Storybook actions パネルで意図通りか