### PR TITLE
refactor(storybook): Storybook 10 イディオムと Button interaction test を追加

### DIFF
--- a/application/.storybook/main.ts
+++ b/application/.storybook/main.ts
@@ -15,5 +15,9 @@ const config: StorybookConfig = {
 	typescript: {
 		reactDocgen: "react-docgen-typescript",
 	},
+
+	core: {
+		disableTelemetry: true,
+	},
 }
 export default config

--- a/application/src/stories/Button.stories.ts
+++ b/application/src/stories/Button.stories.ts
@@ -1,4 +1,4 @@
-import {fn} from "storybook/test"
+import {expect, fn, userEvent, within} from "storybook/test"
 
 import {Button} from "@/components/ui/button"
 
@@ -23,5 +23,11 @@ type Story = StoryObj<typeof meta>
 export const button: Story = {
 	args: {
 		asChild: false,
+		children: "クリック",
+	},
+	play: async ({canvasElement, args}) => {
+		const canvas = within(canvasElement)
+		await userEvent.click(canvas.getByRole("button"))
+		await expect(args.onClick).toHaveBeenCalled()
 	},
 }

--- a/application/src/stories/hit-numbers.stories.ts
+++ b/application/src/stories/hit-numbers.stories.ts
@@ -8,6 +8,7 @@ const meta: Meta<typeof HitNumbers> = {
 	parameters: {
 		layout: "fullscreen",
 	},
+	tags: ["autodocs"],
 } satisfies Meta<typeof HitNumbers>
 
 export default meta

--- a/application/src/stories/number-display.stories.ts
+++ b/application/src/stories/number-display.stories.ts
@@ -8,6 +8,7 @@ const meta: Meta<typeof NumberDisplay> = {
 	parameters: {
 		layout: "fullscreen",
 	},
+	tags: ["autodocs"],
 } satisfies Meta<typeof NumberDisplay>
 
 export default meta


### PR DESCRIPTION
## 期待する挙動・状態

- Storybook 10 の現行イディオムに沿う形に整理し、`Button.stories.ts` に play 関数による interaction test を追加する。
- `.storybook/main.ts` に `core.disableTelemetry: true` を追加し、起動時のテレメトリ送信を抑止する。
- `hit-numbers.stories.ts` / `number-display.stories.ts` の `tags: ["autodocs"]` を明示する (preview の全体設定に加えて story 単位でも宣言)。
- Button の play 関数は `storybook/test` の `expect` / `fn` / `userEvent` / `within` を使い、ボタンをクリックすると `args.onClick` の mock が呼ばれることを検証する。
- Chromatic baseline 影響を避けるため、見た目を変える変更は `chromatic.disableSnapshot: true` の Button story にのみ限定する (`children: "クリック"` を追加)。

## 確認済み項目

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run build-storybook` (`storybook-static/` が生成されることを確認)
- [x] `addons` に `@storybook/addon-vitest` を追加していない (vitest 連携は既存の `vitest.config.ts` 経由のまま)
- [x] `preview.tsx` の既存 decorator (`medievalSharp.className`) を維持
- [x] `hit-numbers` / `number-display` の args・parameters は変更せず、Chromatic baseline を壊さない構成
- [x] commit に Co-Authored-By トレーラを付与していない

## 見てほしいところ

- [ ] `application/src/stories/Button.stories.ts` の play 関数が Storybook 10 の推奨パターン (`storybook/test` の `within` / `userEvent` / `expect`) に沿っているか
- [ ] `application/.storybook/main.ts` の `core.disableTelemetry` 追加位置が他の設定 (framework / staticDirs / typescript) と並んで自然か
- [ ] `tags: ["autodocs"]` の重複宣言 (preview 全体 + 各 story) が許容範囲か (本タスクで明示が求められた)