### PR TITLE
fix: Dependabot auto merge を pull_request で実行

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,7 +1,10 @@
 name: Auto Merge
 
 on:
-  pull_request_target:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要
- Dependabot Auto Merge workflow のトリガーを `pull_request_target` から `pull_request` に変更
- fastify/github-action-merge-dependabot が内部で Dependabot metadata を取得できるイベントに合わせる
- main 向け PR の opened/reopened/ready_for_review/synchronize のみで実行

## 背景
`fastify/github-action-merge-dependabot@v3.12.0` は内部の metadata 取得を `github.event_name == 'pull_request'` の場合だけ実行するため、`pull_request_target` では update type が空になり `Semver bump '\ is invalid!` で auto-merge が有効化されませんでした。\n\n## 権限確認方法\n次の Dependabot PR で Auto Merge workflow のログを確認します。\n\n1. Actions から該当の `Auto Merge` run を開く\n2. `auto-merge` job の `Set up job` にある `GITHUB_TOKEN Permissions` を確認する\n3. `Contents: write` と `PullRequests: write` が表示されれば、workflow に要求した write 権限が実際に付与されています\n4. read-only に落ちている場合や `Resource not accessible by integration` が出る場合は、Dependabot 起点の `pull_request` で write 権限が付与されていないため、この方式では approve / auto-merge できません\n\nCLI で確認する場合:\n\n```bash\ngh run list --workflow "Auto Merge" --branch <dependabot-branch> --limit 1\ngh run view <run-id> --job <job-id> --log | grep -A5 "GITHUB_TOKEN Permissions"\n```\n\n## 検証\n- `git diff --check`\n