### PR TITLE
chore: mise で node/pnpm/terraform/apm を管理 (volta 撤去・pnpm 11 化)

### DIFF
--- a/.apm/instructions/setup.instructions.md
+++ b/.apm/instructions/setup.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: bingo_next の本番環境とローカル環境構築手順
-applyTo: "**/{package.json,pnpm-lock.yaml,tsconfig.json,*.tf,*.tfvars}"
+applyTo: "**/{mise.toml,package.json,pnpm-workspace.yaml,pnpm-lock.yaml,tsconfig.json,*.tf,*.tfvars}"
 ---
 
 # 環境構築
@@ -13,11 +13,11 @@ applyTo: "**/{package.json,pnpm-lock.yaml,tsconfig.json,*.tf,*.tfvars}"
 ## application (Next.js)
 
 - `git clone`
-- volta を設定
-- volta により、node と pnpm を `package.json` で指定されたバージョンをインストールする
-  - `volta install node@${指定バージョン}`
-  - `volta install pnpm@${指定バージョン}`
-- アプリケーションのインストールと起動
+- [mise](https://mise.jdx.dev/) を導入する (node / pnpm / terraform / apm のバージョン管理に使用)
+  - Linux ホストでは pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。GitHub Actions の `ubuntu-latest` には標準装備のため CI では不要。
+- `mise trust && mise install` で `mise.toml` に固定された各ツールを導入する
+  - 以降 `node` / `pnpm` / `terraform` / `apm` が mise 管理版を指すよう、シェルで mise を有効化する (`mise activate` を shell rc に追加。導入方法は[公式手順](https://mise.jdx.dev/getting-started.html)を参照)。有効化しない場合は各コマンドを `mise exec -- <cmd>` で実行する。
+- アプリケーションのインストールと起動 (`application/` で実行)
   - `pnpm i --frozen-lockfile`
   - `pnpm run dev`
 - husky の設定
@@ -28,8 +28,17 @@ applyTo: "**/{package.json,pnpm-lock.yaml,tsconfig.json,*.tf,*.tfvars}"
 
 ## iac (Terraform)
 
-- terraform をローカルにインストール
-  - terraform のバージョンは `iac/hosting/versions.tf` を参照
+- terraform は `mise.toml` で管理する (`mise install` 済みなら追加導入は不要)。バージョン制約は `iac/hosting/versions.tf` の `required_version` を参照。
 - `iac/hosting/` ディレクトリで以下を実行
   - `terraform login`
   - `terraform init`
+
+## バージョン管理 (mise)
+
+node / pnpm / terraform / apm CLI のバージョンはリポジトリ直下の `mise.toml` を唯一の真実源 (SSoT) とする。更新時は `mise.toml` を編集して `mise install` する (apm の `apm self-update` / `apm doctor` の更新催促には従わない)。
+
+- ローカル / CI ともに同じ `mise.toml` を消費する (CI は `jdx/mise-action` 経由で node / pnpm のみ install)。
+- ただし mise が届かない実行環境が 2 つあり、それぞれ別途バージョンを保持・同期する:
+  - **Vercel 本番ビルド**: node は `iac/hosting/project.tf` の `node_version`、pnpm は `package.json` の `packageManager` (corepack) で解決する。`mise.toml` の値と整合させること。
+  - **Terraform Cloud リモート実行**: terraform 版は TFC workspace の設定で解決する。`iac/hosting/versions.tf` の `required_version` 制約を満たすこと。
+- mise 本体は最低 2026.6.1 を要する (pnpm 11.5.2 の aqua アセット解決に必要)。

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,11 +1,7 @@
 name: 'Setup Node and pnpm'
-description: 'Node.jsとpnpmをキャッシュ付きでセットアップして依存関係をインストールします'
+description: 'miseでNode.jsとpnpmをセットアップし、pnpmストアをキャッシュして依存関係をインストールします'
 
 inputs:
-  package-json-path:
-    description: 'package.jsonファイルへのパス'
-    required: false
-    default: 'application/package.json'
   cache-dependency-path:
     description: 'pnpm-lock.yamlファイルへのパス'
     required: false
@@ -18,15 +14,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+    # node / pnpm のバージョンは mise.toml を SSoT とする。terraform / apm は CI で不要なので install 対象外。
+    # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
+    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
-        run_install: false
-        package_json_file: ${{ inputs.package-json-path }}
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        version: 2026.6.1
+        install_args: "node pnpm"
+    - name: Get pnpm store directory
+      shell: bash
+      run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        node-version-file: ${{ inputs.package-json-path }}
-        cache: "pnpm"
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        path: ${{ env.PNPM_STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
     - name: Install Dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/application/package.json
+++ b/application/package.json
@@ -27,11 +27,7 @@
 		"chromatic": "chromatic --only-changed --project-token=${CHROMATIC_PROJECT_TOKEN}",
 		"copilot": "copilot"
 	},
-	"volta": {
-		"node": "24.11.0",
-		"pnpm": "10.24.0"
-	},
-	"packageManager": "pnpm@10.24.0",
+	"packageManager": "pnpm@11.5.2",
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"
@@ -122,17 +118,5 @@
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.60.1",
 		"vitest": "~4.1.8"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@vercel/speed-insights",
-			"esbuild",
-			"sharp"
-		],
-		"ignoredBuiltDependencies": [
-			"core-js-pure",
-			"msw",
-			"unrs-resolver"
-		]
 	}
 }

--- a/application/pnpm-workspace.yaml
+++ b/application/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+allowBuilds:
+  "@vercel/speed-insights": true
+  esbuild: true
+  sharp: true
+  core-js-pure: false
+  msw: false
+  unrs-resolver: false

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+node = "24.16.0"
+pnpm = "11.5.2"
+terraform = "1.15.5"
+"github:microsoft/apm" = {version = "0.18.0", extract_all = "true"}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
 	"name": "bingo-next-workspace",
 	"private": true,
-	"packageManager": "pnpm@10.24.0"
+	"packageManager": "pnpm@11.5.2"
 }


### PR DESCRIPTION
## 期待する挙動・状態

`mise.toml` を node / pnpm / terraform / apm CLI のバージョンの唯一の真実源 (SSoT) とし、ローカルと CI を mise ベースに統一する。volta を撤去し、[PR #383 (ROhta/bingo)](https://github.com/ROhta/bingo/pull/383) と同様の方針を bingo_next の構成 (application/ 配下・Vercel ホスティング・Terraform Cloud) に合わせて適用する。

確定バージョン: node `24.16.0` / pnpm `11.5.2` / terraform `1.15.5` / apm `0.18.0`

### 主な変更

- `mise.toml` を新規追加 (リポジトリ直下、4 ツールを exact ピン)
- `application/package.json` の `volta` ブロックを削除し、`packageManager` を `pnpm@11.5.2` に同期 (root も)
- pnpm 11 で読まれなくなった `package.json` の `pnpm` 欄 (`onlyBuiltDependencies` / `ignoredBuiltDependencies`) を `application/pnpm-workspace.yaml` の `allowBuilds` へ移行
- CI コンポジット `setup-node-pnpm` を `jdx/mise-action` (SHA ピン・`version: 2026.6.1`・`install_args: "node pnpm"`) へ移行。`setup-node` の `cache: pnpm` 喪失分を `actions/cache` (pnpm store) で補填
- 環境構築手順 (`.apm/instructions/setup.instructions.md`) を mise ベースへ更新

### mise の外に残るバージョン (要同期)

bingo_next は Vercel / Terraform Cloud が mise の外で動くため、SSoT は完全一本化されず分散する:

- **Vercel 本番ビルド**: node は `iac/hosting/project.tf` の `node_version = "24.x"`、pnpm は `packageManager` (corepack)。mise が届かないため別管理。
- **Terraform Cloud リモート実行**: terraform 版は TFC workspace 設定。`iac/hosting/versions.tf` の `required_version = "~> 1.13"` 制約は 1.15.5 で充足 (`~> 1.13` = `>= 1.13, < 2.0`)。

## 確認済み項目

- [x] ローカル: `mise install` で node 24.16.0 / pnpm 11.5.2 / terraform 1.15.5 / apm 0.18.0 を解決
- [x] ローカル: `pnpm i --frozen-lockfile` → `pnpm run build` (Next.js ビルド成功) / `pnpm run lint` (eslint 通過) / `vitest run` (4 passed)
- [x] pnpm 11 のビルドスクリプト許可 (esbuild / sharp) が `allowBuilds` で動作することを fresh install で確認 (`ERR_PNPM_IGNORED_BUILDS` 解消)
- [x] `pnpm-lock.yaml` は lockfileVersion 9.0 のまま pnpm 11 と互換 (再生成不要)
- [x] `actionlint` 通過 (workflow + composite)
- [x] Allowed Actions に `jdx/mise-action@*` を追加済み

## 見てほしいところ

- [ ] pnpm 10→11 のメジャー更新を本 PR に同梱している点 (当初は別 PR 案だったが、依存設定の移行が小さく lockfile 再生成も不要なため同梱)
- [ ] terraform は絶対最新 1.15.5。TFC workspace の Terraform Version 設定との乖離があれば要同期
- [ ] `pnpm/action-setup@*` は本 PR マージ後に不要化するが、main の CI 保護のため Allowed Actions からの削除はマージ後に行う想定
