### PR TITLE
chore: apm.yml の description を日本語に統一

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -1,6 +1,6 @@
 name: bingo-next
 version: 0.1.0
-description: AI agent instructions for the bingo_next project
+description: bingo_next プロジェクトの AI エージェント向け指示
 author: ROhta
 type: instructions
 targets:


### PR DESCRIPTION
## 期待する挙動・状態

- `apm.yml` の `description` フィールドを英語から日本語へ変更し、リポジトリ内の説明文言の言語を日本語で統一する
  - 変更前: `AI agent instructions for the bingo_next project`
  - 変更後: `bingo_next プロジェクトの AI エージェント向け指示`
- `description` はパッケージのメタ情報であり、`apm compile` が生成する `CLAUDE.md` / instructions の本文には展開されないため、生成物への影響はない

## 確認済み項目

- [x] `apm.yml` の YAML 構文が妥当であること (`yaml.safe_load` で検証)
- [x] 旧英語文言 `AI agent instructions for the bingo_next project` がリポジトリ内に残存していないこと (grep で確認)
- [x] 作業ツリーがクリーンで、差分が `apm.yml` 1 行のみであること

## 見てほしいところ

- [x] 日本語訳 `bingo_next プロジェクトの AI エージェント向け指示` の文言が適切か