### PR TITLE
fix: Dependabot PR の auto-merge ブロック要因を解消（二重 approve / Chromatic 必須チェック未報告）

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,9 +24,12 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+    # dependabot PR でもジョブは実行し、chromaui/action の skip: "dependabot**" で
+    # ビルドはスキップしつつ Run Chromatic / UI Review / UI Tests を pass として投稿する。
+    # ジョブ自体を除外すると必須チェックが未報告のままになり auto-merge がブロックされるため。
     if: |
       github.event_name == 'push' ||
-      (github.event.pull_request.draft == false && github.actor != 'dependabot[bot]')
+      github.event.pull_request.draft == false
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1.0.2-beta9
         with:

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -23,20 +23,6 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1.0.2-beta9
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - name: Fetch Dependabot metadata
-        id: meta
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-      - name: Approve PR
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)" = "APPROVED" ]; then
-            echo "PR already approved, skipping."
-          else
-            gh pr review --approve "$PR_URL"
-          fi
       - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
         with:
           use-github-auto-merge: true


### PR DESCRIPTION
## 期待する挙動・状態

- Dependabot PR への approve が 1 回だけ付く
- Dependabot PR でも `Run Chromatic` / `UI Review` / `UI Tests` の必須チェックが pass として報告され、auto-merge がブロックされない

Dependabot PR の自動マージにまつわる 2 つの問題をまとめて解消する。

### 1. approve が二重に付与される ([#705](https://github.com/ROhta/bingo_next/pull/705) など)

`github-actions[bot]` が同一コミットに 1 秒差で 2 回 approve していた。1 回の Auto Merge 実行内で approve が二重に走っていたのが原因:

1. 自前の `Approve PR` ステップ (`gh pr review --approve`)
2. `fastify/github-action-merge-dependabot` (説明文 `Automatically approve and merge dependabot PRs` の通り action 自身が approve する)

merge action が approve + auto-merge を担うため、自前の `Approve PR` ステップと、その `if` でしか参照していない `Fetch Dependabot metadata` (fetch-metadata) ステップを削除し、approve を merge action に一任する。`target: "minor"` のままなので major 更新の挙動は変わらない。

### 2. Chromatic 必須チェックが未報告で BLOCKED になる ([#705](https://github.com/ROhta/bingo_next/pull/705))

ルールセット「production ready」は `Run Chromatic` / `UI Review` / `UI Tests` を必須チェックに指定しているが、`chromatic.yml` のジョブ `if` が `github.actor != 'dependabot[bot]'` でジョブごと除外していたため、Dependabot PR ではこれらが skipped / 未報告のままになり `BLOCKED` が解除されず auto-merge が発火しなかった。

ジョブ自体は実行させ、既存の `chromaui/action` の `skip: "dependabot**"` でビルドをスキップしつつ必須チェックを pass として投稿させる（スナップショットは消費しない）。`if` とアクションの `skip:` の意図が衝突していたのを解消する形。

## 確認済み項目

- [x] `dependabot-merge.yml` の approve がmerge action 1 つに集約されていること
- [x] `chromatic.yml` の `skip: "dependabot**"` が維持され、ジョブ除外のみ解除されていること
- [x] 各 YAML の構文が壊れていないこと

## 見てほしいところ

- [ ] `chromatic.yml`: dependabot 以外の非 draft PR の挙動は従来どおり（`skip` にマッチしないため通常実行）である点
- [ ] `dependabot-merge.yml`: `Approve PR` ステップ削除で major 更新の「マージせず approve だけ」挙動が失われるが、元々ガードでスキップ・fastify も `target: "minor"` で major 非マージのため実質後退がない点

🤖 Generated with [Claude Code](https://claude.com/claude-code)